### PR TITLE
feat: client schema compatibility and filterFields

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,9 @@ Returns an AST representation of the provided `schema`.
 
 Accepts an optional `options` object containing the following properties:
 
- - **`filterTypes`: `string[] | (GraphQLNamedType) => boolean`** - Accepts an array of type names that will be filtered out of the returned AST. Alternatively a custom filter function can be passed in.
- - **`filterDirectives`: `string[] | (GraphQLDirective) => boolean`** - Accepts an array of directive names that will be filtered out of the returned AST. Alternatively a custom filter function can be passed in.
- - **`filterFields`: `{ [string]: string[] } | (GraphQLDirective) => boolean`** - Accepts an Object with keys of type names and values of arrays of field names to filter out of the returned AST. Alternatively a custom filter function can be passed in.
+ - **`filterTypes`: `string[] | (TypeDefinitionNode) => boolean`** - Accepts an array of type names that will be filtered out of the returned AST. Alternatively a custom filter function can be passed in.
+ - **`filterDirectives`: `string[] | (DirectiveDefinitionNode) => boolean`** - Accepts an array of directive names that will be filtered out of the returned AST. Alternatively a custom filter function can be passed in.
+ - **`filterFields`: `{ [string]: string[] } | (FieldDefinitionNode, TypeDefinitionNode) => boolean`** - Accepts an object with keys of type names and values of arrays of field names to filter out of the returned AST. Alternatively a custom filter function can be passed in - the function will receive the current field (`FieldDefinitionNode`) and the parent type (`TypeDefinitionNode`).
 
 ##### Example
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,11 @@ const federatedSchema = require('./schema')
 
 const SDL = printSDL(federatedSchema, {
   minify: true,
-  filterDirectives: ['key', 'external', 'requires', 'provides', 'extends']
+  filterDirectives: ['key', 'external', 'requires', 'provides', 'extends'],
+  filterFields: {
+    Query: ['_service', '_entities']
+  },
+  filterTypes: ['_Any', '_FieldSet', '_Service']
 })
 ```
 
@@ -187,6 +191,7 @@ const document = astFromSchema(federatedSchema, {
   filterDirectives: ['key', 'external', 'requires', 'provides', 'extends'],
   filterFields: {
     Query: ['_service', '_entities']
-  }
+  },
+  filterTypes: ['_Any', '_FieldSet', '_Service']
 })
 ```

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Accepts an optional `options` object containing the following properties:
 
  - **`filterTypes`: `string[] | (GraphQLNamedType) => boolean`** - Accepts an array of type names that will be filtered out of the returned AST. Alternatively a custom filter function can be passed in.
  - **`filterDirectives`: `string[] | (GraphQLDirective) => boolean`** - Accepts an array of directive names that will be filtered out of the returned AST. Alternatively a custom filter function can be passed in.
+ - **`filterFields`: `{ [string]: string[] } | (GraphQLDirective) => boolean`** - Accepts an Object with keys of type names and values of arrays of field names to filter out of the returned AST. Alternatively a custom filter function can be passed in.
 
 ##### Example
 
@@ -183,6 +184,9 @@ const { astFromSchema } = require('@autotelic/graphql-schema-tools')
 const federatedSchema = require('./schema')
 
 const document = astFromSchema(federatedSchema, {
-  filterDirectives: ['key', 'external', 'requires', 'provides', 'extends']
+  filterDirectives: ['key', 'external', 'requires', 'provides', 'extends'],
+  filterFields: {
+    Query: ['_service', '_entities']
+  }
 })
 ```

--- a/lib/astFromSchema/index.js
+++ b/lib/astFromSchema/index.js
@@ -1,23 +1,26 @@
+const { Kind, parse, printType, isIntrospectionType, isType, isSpecifiedScalarType, isSpecifiedDirective } = require('graphql')
 const sortASTs = require('../sortASTNodes')
 
-const createNameFilter = (names) => ({ name }) => !names.includes(name.value)
+const createNameFilter = (names) => (obj) => !names.includes(obj.name.value)
+// Used if schema is either the result of introspection or contains a subschema created via introspection.
+const createFallbackAST = (type) => parse(printType(type)).definitions[0]
 
-function extractASTNodes (obj) {
-  let definitions = []
-  if (obj.astNode) {
-    definitions.push(obj.astNode)
-  }
-  if (obj.extensionASTNodes) {
-    definitions = definitions.concat(obj.extensionASTNodes)
-  }
-  return definitions
-}
-
-function astFromSchema (schema, opts) {
+function astFromSchema (schema, opts = {}) {
   const {
     filterDirectives = [],
-    filterTypes = []
+    filterTypes = [],
+    filterFields = {}
   } = opts
+
+  const handleFieldsFilter = typeof filterFields === 'function'
+    ? filterFields
+    : (target, parent) => {
+        try {
+          return !filterFields[parent.name.value].includes(target.name.value)
+        } catch (error) {
+          return true
+        }
+      }
 
   const handleTypesFilter = Array.isArray(filterTypes)
     ? createNameFilter(filterTypes)
@@ -27,16 +30,68 @@ function astFromSchema (schema, opts) {
     ? createNameFilter(filterDirectives)
     : filterDirectives
 
+  function extractASTNodes (obj) {
+    // We want to ignore all built-in definitions.
+    if (!isIntrospectionType(obj) && !isSpecifiedScalarType(obj) && !isSpecifiedDirective(obj)) {
+      // If a type contains fields, do not extract the top-level astNode and extensionASTNodes.
+      // Instead, construct a single astNode containing the nodes of each field.
+      if (obj._fields) {
+        // Some schemas may contain types and fields with undefined astNodes (ie. client schemas).
+        // If an astNode is undefined, we can create our own...
+        const { fields: astFields, ...astNode } = obj.astNode || createFallbackAST(obj)
+        const objFields = Object.values(obj.getFields())
+        astNode.fields = objFields.map(({ name, astNode }) => {
+          // If a field does not contain an astNode...
+          if (!astNode) {
+            // fallback to the field contained in the parent types astNode.
+            return astFields.find((ast) => name === ast.name.value)
+          }
+          return astNode
+        })
+        astNode.fields = astNode.fields.filter((field) => field && handleFieldsFilter(field, astNode))
+        return astNode
+      }
+      if (obj.astNode) {
+        // If extensions exist, merge them and the original astNode into a new astNode.
+        if (Array.isArray(obj.extensionASTNodes)) {
+          return obj.extensionASTNodes.reduce((acc, extNode) => {
+            const { name, description, kind, loc, ...extProps } = extNode
+            Object.entries(extProps).forEach(([key, value]) => {
+              if (Array.isArray(value)) {
+                if (Array.isArray(acc[key])) {
+                  acc[key] = acc[key].concat(value)
+                } else {
+                  acc[key] = value
+                }
+              }
+            })
+            return acc
+          }, { ...obj.astNode })
+        }
+        return obj.astNode
+      }
+      // There is no need to provide fallbacks for directives, as client schemas do not represent
+      // any server-internal mechanisms (including directives).
+      if (isType(obj)) {
+        return createFallbackAST(obj)
+      }
+    }
+  }
+
   const {
     types,
     directives
   } = schema.toConfig()
 
-  const typeNodes = types.flatMap(extractASTNodes).filter(handleTypesFilter)
-  const directiveNodes = directives.flatMap(extractASTNodes).filter(handleDirectivesFilter)
+  const typeNodes = types.map(extractASTNodes).filter(
+    (node) => node && handleTypesFilter(node)
+  )
+  const directiveNodes = directives.map(extractASTNodes).filter(
+    (node) => node && handleDirectivesFilter(node)
+  )
 
   return {
-    kind: 'Document',
+    kind: Kind.DOCUMENT,
     definitions: sortASTs([...typeNodes, ...directiveNodes])
   }
 }

--- a/lib/astFromSchema/index.js
+++ b/lib/astFromSchema/index.js
@@ -36,15 +36,18 @@ function astFromSchema (schema, opts = {}) {
       // If a type contains fields, do not extract the top-level astNode and extensionASTNodes.
       // Instead, construct a single astNode containing the nodes of each field.
       if (obj._fields) {
-        // Some schemas may contain types and fields with undefined astNodes (ie. client schemas).
+        // Some schemas may contain types with undefined astNodes (ie. client schemas).
         // If an astNode is undefined, we can create our own...
         const { fields: astFields, ...astNode } = obj.astNode || createFallbackAST(obj)
         const objFields = Object.values(obj.getFields())
+        // Some types in stitched schemas may have a defined astNode, but contain _fields with undefined astNodes.
+        // Fields with undefined astNodes will not exist in the parent's astNode.fields - so we need a separate fallback.
+        let fallbackAST
         astNode.fields = objFields.map(({ name, astNode }) => {
-          // If a field does not contain an astNode...
           if (!astNode) {
-            // fallback to the field contained in the parent types astNode.
-            return astFields.find((ast) => name === ast.name.value)
+            // Instead of creating a new fallback for every field...
+            if (!fallbackAST) fallbackAST = createFallbackAST(obj)
+            return fallbackAST.fields.find((ast) => name === ast.name.value)
           }
           return astNode
         })

--- a/lib/astFromSchema/index.test.js
+++ b/lib/astFromSchema/index.test.js
@@ -1,5 +1,6 @@
 const { test } = require('tap')
 const { buildSchema, print, buildClientSchema, parse, introspectionFromSchema, buildASTSchema } = require('graphql')
+const { stitchSchemas } = require('@graphql-tools/stitch')
 const astFromSchema = require('.')
 
 const schemaSDL = `
@@ -193,6 +194,63 @@ union Something = Bar | Baz | Foo
   equal(print(actual), expected)
 })
 
+test('astFromSchema - can handle stitched schemas', async ({ equal }) => {
+  const subschemaOne = buildClientSchema(introspectionFromSchema(buildASTSchema(parse(schemaSDL))))
+  const subschemaTwo = buildSchema(`
+  type Foo {
+    id: ID!
+  }
+
+  type Query {
+    allFoo: [Foo]
+  }
+  `)
+
+  const stitchedSchema = stitchSchemas({
+    subschemas: [subschemaOne, subschemaTwo]
+  })
+
+  const actual = astFromSchema(stitchedSchema)
+  const expected = `scalar BAR
+
+scalar FOO
+
+scalar HELLO_WORLD
+
+enum Stuff {
+  BAR
+  FOO
+  HELLO_WORLD
+}
+
+type Bar {
+  foo: String
+}
+
+type Baz {
+  fooBar: String
+}
+
+type Foo {
+  bar: String
+  id: ID!
+}
+
+type Query {
+  allFoo: [Foo]
+  getBar(foo: String): Bar
+  getBaz: Baz
+  getFoo(bar: String = "bar"): Foo
+  getSomething: Something
+  getStuff: Stuff
+}
+
+union Something = Bar | Baz | Foo
+`
+  // Compare printed ASTs so tap doesn't timeout comparing DocumentNodes.
+  equal(print(actual), expected)
+})
+
 test('astFromSchema - can handle undefined property values in extension nodes', async ({ equal, same }) => {
   const schema = {
     toConfig: () => ({
@@ -223,7 +281,6 @@ test('astFromSchema - can handle undefined property values in extension nodes', 
     })
   }
 
-  // Compare printed ASTs so tap doesn't timeout comparing DocumentNodes.
   same(astFromSchema(schema), {
     kind: 'Document',
     definitions: [

--- a/lib/astFromSchema/index.test.js
+++ b/lib/astFromSchema/index.test.js
@@ -1,65 +1,248 @@
 const { test } = require('tap')
-const { buildSchema, print } = require('graphql')
+const { buildSchema, print, buildClientSchema, parse, introspectionFromSchema, buildASTSchema } = require('graphql')
 const astFromSchema = require('.')
 
-const source = `directive @testing on FIELD_DEFINITION
-    type Foo {
-      id: ID! @testing
-      name: String!
-    }
+const schemaSDL = `
+directive @testing on FIELD_DEFINITION
+directive @another on FIELD_DEFINITION
 
-    input NewFoo {
-      name: String!
-      description: String
-    }
+scalar HELLO_WORLD
+scalar FOO
+scalar BAR
 
-    type Mutation {
-      bar(foo: NewFoo): NewFoo
-    }
+enum Stuff {
+  FOO
+}
 
-    type Query {
-      foo: Foo
-    }
-  `
+extend enum Stuff {
+  HELLO_WORLD
+}
 
-test('astFromSchema - filterTypes and filterDirectives accepts array of names', async ({ equal }) => {
-  const schema = buildSchema(source)
+extend enum Stuff {
+  BAR
+}
+
+type Foo {
+  bar: String
+}
+
+type Bar {
+  foo: String
+}
+
+type Baz {
+  fooBar: String
+}
+
+union Something = Foo | Bar
+
+extend union Something = Baz
+
+type Query {
+  getFoo(bar: String = "bar"): Foo @testing
+}
+
+extend type Query {
+  getBar(foo: String): Bar @testing
+}
+
+extend type Query {
+  getBaz: Baz
+  getSomething: Something
+  getStuff: Stuff
+}
+`
+
+test('astFromSchema', async ({ equal }) => {
+  const schema = buildSchema(schemaSDL)
 
   const actual = astFromSchema(schema, {
-    filterTypes: ['NewFoo', 'Mutation'],
-    filterDirectives: ['testing']
+    filterFields: ['getBaz', 'getBar']
   })
+  const expected = `directive @another on FIELD_DEFINITION
 
-  const expected = `type Foo {
-  id: ID! @testing
-  name: String!
+directive @testing on FIELD_DEFINITION
+
+scalar BAR
+
+scalar FOO
+
+scalar HELLO_WORLD
+
+enum Stuff {
+  BAR
+  FOO
+  HELLO_WORLD
+}
+
+type Bar {
+  foo: String
+}
+
+type Baz {
+  fooBar: String
+}
+
+type Foo {
+  bar: String
 }
 
 type Query {
-  foo: Foo
+  getBar(foo: String): Bar @testing
+  getBaz: Baz
+  getFoo(bar: String = "bar"): Foo @testing
+  getSomething: Something
+  getStuff: Stuff
+}
+
+union Something = Bar | Baz | Foo
+`
+  // Compare printed ASTs so tap doesn't timeout comparing DocumentNodes.
+  equal(print(actual), expected)
+})
+
+test('astFromSchema - filterTypes, filterDirectives, and filterFields', async ({ equal }) => {
+  const schema = buildSchema(schemaSDL)
+
+  const actual = astFromSchema(schema, {
+    filterFields: { Query: ['getBaz', 'getBar', 'getSomething', 'getStuff'] },
+    filterTypes: ['BAR', 'FOO', 'HELLO_WORLD', 'Stuff', 'Something', 'Bar', 'Baz'],
+    filterDirectives: ['another']
+  })
+  const expected = `directive @testing on FIELD_DEFINITION
+
+type Foo {
+  bar: String
+}
+
+type Query {
+  getFoo(bar: String = "bar"): Foo @testing
 }
 `
   // Compare printed ASTs so tap doesn't timeout comparing DocumentNodes.
   equal(print(actual), expected)
 })
 
-test('astFromSchema - filterTypes and filterDirectives accepts functions', async ({ equal }) => {
-  const schema = buildSchema(source)
+test('astFromSchema - filterTypes, filterDirectives, and filterFields accepts functions', async ({ equal }) => {
+  const schema = buildSchema(schemaSDL)
 
   const actual = astFromSchema(schema, {
-    filterTypes: ({ name }) => !['NewFoo', 'Mutation'].includes(name.value),
-    filterDirectives: ({ name }) => !['testing'].includes(name.value)
+    filterTypes: ({ name }) => ['Foo', 'Query'].includes(name.value),
+    filterDirectives: ({ name }) => ['testing'].includes(name.value),
+    filterFields: (field, type) => {
+      if (type.name.value === 'Query') {
+        return field.name.value === 'getFoo'
+      }
+      return true
+    }
   })
 
-  const expected = `type Foo {
-  id: ID! @testing
-  name: String!
+  const expected = `directive @testing on FIELD_DEFINITION
+
+type Foo {
+  bar: String
 }
 
 type Query {
-  foo: Foo
+  getFoo(bar: String = "bar"): Foo @testing
 }
 `
   // Compare printed ASTs so tap doesn't timeout comparing DocumentNodes.
   equal(print(actual), expected)
+})
+
+test('astFromSchema - can handle client schemas (undefined astNodes)', async ({ equal }) => {
+  const schema = buildClientSchema(introspectionFromSchema(buildASTSchema(parse(schemaSDL))))
+  const actual = astFromSchema(schema)
+
+  const expected = `scalar BAR
+
+scalar FOO
+
+scalar HELLO_WORLD
+
+enum Stuff {
+  BAR
+  FOO
+  HELLO_WORLD
+}
+
+type Bar {
+  foo: String
+}
+
+type Baz {
+  fooBar: String
+}
+
+type Foo {
+  bar: String
+}
+
+type Query {
+  getBar(foo: String): Bar
+  getBaz: Baz
+  getFoo(bar: String = "bar"): Foo
+  getSomething: Something
+  getStuff: Stuff
+}
+
+union Something = Bar | Baz | Foo
+`
+  // Compare printed ASTs so tap doesn't timeout comparing DocumentNodes.
+  equal(print(actual), expected)
+})
+
+test('astFromSchema - can handle undefined property values in extension nodes', async ({ equal, same }) => {
+  const schema = {
+    toConfig: () => ({
+      types: [
+        {
+          astNode: {
+            name: { value: 'MyEnum' },
+            kind: 'EnumTypeDefinition',
+            values: [{
+              kind: 'EnumValueDefinition',
+              name: { value: 'MyEnumValue' }
+            }]
+          },
+          extensionASTNodes: [{
+            kind: 'EnumTypeExtension',
+            name: { value: 'MyEnum' },
+            values: undefined,
+            directives: [
+              {
+                kind: 'Directive',
+                name: 'deprecated'
+              }
+            ]
+          }]
+        }
+      ],
+      directives: []
+    })
+  }
+
+  // Compare printed ASTs so tap doesn't timeout comparing DocumentNodes.
+  same(astFromSchema(schema), {
+    kind: 'Document',
+    definitions: [
+      {
+        name: {
+          value: 'MyEnum'
+        },
+        kind: 'EnumTypeDefinition',
+        directives: [
+          {
+            kind: 'Directive',
+            name: 'deprecated'
+          }
+        ],
+        values: [{
+          kind: 'EnumValueDefinition',
+          name: { value: 'MyEnumValue' }
+        }]
+      }
+    ]
+  })
 })

--- a/lib/printSDL/index.test.js
+++ b/lib/printSDL/index.test.js
@@ -1,47 +1,27 @@
 const { test } = require('tap')
 const { buildSchema } = require('graphql')
 const printSDL = require('.')
-const normalizeGQLSource = require('../normalizeGQLSource')
 
 const source = `directive @testing on FIELD_DEFINITION
-    type Foo {
-      id: ID! @testing
-      name: String!
-    }
-    type Bar { id: ID! name: String }
 
-    extend type Foo {
-      description: String
-    }
+type Query {
+  foo: String! @testing
+}
+`
 
-    input NewFoo {
-      name: String!
-      description: String
-    }
-
-    type Mutation {
-      bar(foo: NewFoo): NewFoo
-    }
-
-    type Query {
-      foo: Foo
-    }
-  `
-
-test('printSDL - given a GraphQLSchema, should return a normalized SDL string', async ({ equal }) => {
+test('printSDL - given a GraphQLSchema and no opts, should return a normalized SDL string', async ({ equal }) => {
   const schema = buildSchema(source)
 
   const actual = printSDL(schema)
-  const expected = normalizeGQLSource(source)
 
-  equal(actual, expected.source)
+  equal(actual, source)
 })
 
 test('printSDL - should return a minified SDL when opts.minify is true', async ({ equal }) => {
   const schema = buildSchema(source)
 
   const actual = printSDL(schema, { minify: true })
-  const expected = normalizeGQLSource(source, { minify: true })
+  const expected = 'directive @testing on FIELD_DEFINITION type Query{foo:String! @testing}'
 
-  equal(actual, expected.source)
+  equal(actual, expected)
 })

--- a/lib/sortASTNodes/index.js
+++ b/lib/sortASTNodes/index.js
@@ -47,13 +47,15 @@ function sortDefinitions (definitions) {
 
 function sortDefinitionNode (definition) {
   return Object.entries(definition).reduce((acc, [key, value]) => {
-    if (key === 'fields' || key === 'directives' || key === 'arguments' || key === 'values' || key === 'types' || key === 'interfaces') {
-      acc[key] = value.map(sortDefinitionNode).sort(compareNodeByName)
-      return acc
-    }
-    if (key === 'locations') {
-      acc[key] = value.sort((a, b) => defaultCompare(a.value, b.value))
-      return acc
+    if (Array.isArray(value)) {
+      if (key === 'fields' || key === 'directives' || key === 'arguments' || key === 'values' || key === 'types' || key === 'interfaces') {
+        acc[key] = value.map(sortDefinitionNode).sort(compareNodeByName)
+        return acc
+      }
+      if (key === 'locations') {
+        acc[key] = value.sort((a, b) => defaultCompare(a.value, b.value))
+        return acc
+      }
     }
     acc[key] = value
     return acc

--- a/lib/sortASTNodes/index.test.js
+++ b/lib/sortASTNodes/index.test.js
@@ -1,0 +1,10 @@
+const { test } = require('tap')
+const sortASTNodes = require('.')
+
+test('sortASTNodes - unexpected keys and values', async ({ same }) => {
+  const nodes = [
+    { foo: [], bar: undefined }
+  ]
+
+  same(sortASTNodes(nodes), nodes, 'unexpected keys and values should remain unchanged')
+})

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "homepage": "https://github.com/autotelic/graphql-schema-tools#readme",
   "devDependencies": {
+    "@graphql-tools/stitch": "^7.5.3",
     "graphql": "^15.5.0",
     "standard": "^16.0.3",
     "tap": "^15.0.9"


### PR DESCRIPTION
### Summary
 - Branched off #4 
 - Adds compatibility with schemas created via introspection (ie. client schemas)
   - We needed to provide a fallback, as these schema's have type definitions with undefined `astNodes`.
 - Adds the `filterFields` option 